### PR TITLE
docs: fix for run docker command with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The image is based off the official Debian-slim (stretch) because it's fairly sl
 
 Providing you have access to Docker, you can run the latest version quite easily by:
 
-    docker run -t mitchins/micropython-linux
+    docker run -it mitchins/micropython-linux
     MicroPython v1.9.4-403-g81e320ae on 2018-07-21; linux version
     Use Ctrl-D to exit, Ctrl-E for paste mode
     >>> ^C


### PR DESCRIPTION
Great work on the docker image.
This pull request is just for a small change on the readme to use **-it** instead of **-t**. With **-t** it was not able to type anything on the terminal 