### PR TITLE
Update build dependencies and commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
 FROM debian:stretch-slim
 
 RUN apt-get update && \
-    apt-get install -y build-essential libffi-dev git pkg-config python python3 && \
+    apt-get install -y build-essential libffi-dev git pkg-config python3 && \
     rm -rf /var/lib/apt/lists/* && \
     git clone https://github.com/micropython/micropython.git && \
     cd micropython && \
-    git submodule update --init && \
     cd mpy-cross && \
     make && \
     cd .. && \
     cd ports/unix && \
-    make axtls && \
+    make submodules && \
     make && \
     make test && \
     make install && \
-    apt-get purge --auto-remove -y  build-essential libffi-dev git pkg-config python python3 && \
+    apt-get purge --auto-remove -y build-essential libffi-dev git pkg-config python3 && \
     cd ../../.. && \
     rm -rf micropython
 
 CMD ["/usr/local/bin/micropython"]
-


### PR DESCRIPTION
* Python 2 not needed anymore.
* Git sub-modules are checked out and updates by `make submodules`.
* `make axtls` is obsolete.
