### PR TITLE
fix: update base image to bullseye-slim for up-to-date Python, fixing failing tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
     apt-get install -y build-essential libffi-dev git pkg-config python3 && \


### PR DESCRIPTION
See also comments on #4.
